### PR TITLE
feat(RUB-37816): Add automatic rotation for service account tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Examples codified under the [`examples`](https://github.com/terraform-aws-module
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.63 |
+| <a name="provider_time"></a> [time](#provider\_time) | n/a |
 
 ## Modules
 
@@ -109,6 +110,7 @@ No modules.
 | [aws_iam_role_policy_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_security_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group_rule.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [time_rotating.servic_account_token](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/rotating) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.assume](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |

--- a/main.tf
+++ b/main.tf
@@ -113,7 +113,11 @@ resource "aws_grafana_workspace_api_key" "this" {
 ################################################################################
 # Workspace Service Account
 ################################################################################
+resource "time_rotating" "servic_account_token" {
+  for_each = { for k, v in var.workspace_service_account_tokens : k => v if var.create }
 
+  rotation_minutes = each.value.seconds_to_live / 60
+}
 resource "aws_grafana_workspace_service_account" "this" {
   for_each = { for k, v in var.workspace_service_accounts : k => v if var.create }
 
@@ -129,6 +133,10 @@ resource "aws_grafana_workspace_service_account_token" "this" {
   service_account_id = try(aws_grafana_workspace_service_account.this[each.value.service_account_key].service_account_id, each.value.service_account_id)
   seconds_to_live    = each.value.seconds_to_live
   workspace_id       = local.workspace_id
+
+  lifecycle {
+    replace_triggered_by = [ time_rotating.servic_account_token[each.key] ]
+  }
 }
 
 ################################################################################

--- a/main.tf
+++ b/main.tf
@@ -113,11 +113,13 @@ resource "aws_grafana_workspace_api_key" "this" {
 ################################################################################
 # Workspace Service Account
 ################################################################################
+
 resource "time_rotating" "servic_account_token" {
   for_each = { for k, v in var.workspace_service_account_tokens : k => v if var.create }
 
   rotation_minutes = each.value.seconds_to_live / 60
 }
+
 resource "aws_grafana_workspace_service_account" "this" {
   for_each = { for k, v in var.workspace_service_accounts : k => v if var.create }
 
@@ -135,7 +137,7 @@ resource "aws_grafana_workspace_service_account_token" "this" {
   workspace_id       = local.workspace_id
 
   lifecycle {
-    replace_triggered_by = [ time_rotating.servic_account_token[each.key] ]
+    replace_triggered_by = [time_rotating.servic_account_token[each.key]]
   }
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -44,6 +44,7 @@ output "workspace_service_accounts" {
 output "workspace_service_account_tokens" {
   description = "The workspace service account tokens created including their attributes"
   value       = aws_grafana_workspace_service_account_token.this
+  sensitive   = true
 }
 
 ################################################################################

--- a/outputs.tf
+++ b/outputs.tf
@@ -29,6 +29,7 @@ output "workspace_grafana_version" {
 output "workspace_api_keys" {
   description = "The workspace API keys created including their attributes"
   value       = aws_grafana_workspace_api_key.this
+  sensitive   = true
 }
 
 ################################################################################


### PR DESCRIPTION
## Summary

- Add `time_rotating` resource to automatically trigger service account token regeneration
- Configure `replace_triggered_by` lifecycle on service account tokens to rotate based on the time_rotating resource
- Mark `workspace_api_keys` and `workspace_service_account_tokens` outputs as sensitive to prevent accidental exposure in logs

## Changes

- **main.tf**: Added `time_rotating.servic_account_token` resource that rotates based on `seconds_to_live / 60` minutes. Added `lifecycle.replace_triggered_by` to `aws_grafana_workspace_service_account_token.this` to trigger token regeneration
- **outputs.tf**: Added `sensitive = true` to both `workspace_api_keys` and `workspace_service_account_tokens` outputs
- **README.md**: Updated documentation to reflect new provider and resource

## Testing

- [ ] Terraform plan shows no unexpected changes
- [ ] Token rotation works as expected when time_rotating triggers