### PR TITLE
Fix: Mark workspace_service_account_tokens as sensitive

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -43,6 +43,7 @@ output "workspace_service_accounts" {
 output "workspace_service_account_tokens" {
   description = "The workspace service account tokens created including their attributes"
   value       = aws_grafana_workspace_service_account_token.this
+  sensitive   = true
 }
 
 ################################################################################


### PR DESCRIPTION
Hello Folks,

I'm using this terraform module with my terragrunt code and I found that when I try to set service account tokens, the terragrunt plan fails because the `aws_grafana_workspace_service_account_token.this` output is not marked as sensitive: 

<img width="2072" height="786" alt="image" src="https://github.com/user-attachments/assets/6e489490-2201-4ae6-a80a-f0cebc00cf85" />

In my case, I was able to circumvect this problem with an output override like the one bellow:

```
generate "sensitive_outputs_override" {
  path      = "outputs_override.tf"
  if_exists = "overwrite_terragrunt"
  contents  = <<-EOF
    output "workspace_service_account_tokens" {
      sensitive = true
    }
  EOF
}
```


If you think that this is an welcome or acceptable contribution, please accept.

Regards,

Gabriel

