### PR TITLE
fix: Update GitHub Actions and pre-commit hook versions

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -8,7 +8,7 @@ jobs:
   lock:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@v5
+      - uses: dessant/lock-threads@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           issue-comment: >

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -7,8 +7,8 @@ on:
       - master
 
 env:
-  TERRAFORM_DOCS_VERSION: v0.20.0
-  TFLINT_VERSION: v0.59.1
+  TERRAFORM_DOCS_VERSION: v0.24.0
+  TFLINT_VERSION: v0.64.0
 
 jobs:
   collectInputs:
@@ -18,7 +18,7 @@ jobs:
       directories: ${{ steps.dirs.outputs.directories }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Get root directories
         id: dirs
@@ -33,7 +33,7 @@ jobs:
         directory: ${{ fromJson(needs.collectInputs.outputs.directories) }}
     steps:
       - name: Install rmz
-        uses: jaxxstorm/action-install-gh-release@v2.1.0
+        uses: jaxxstorm/action-install-gh-release@v3.0.0
         with:
           repo: SUPERCILEX/fuc
           asset-name: x86_64-unknown-linux-gnu-rmz
@@ -63,11 +63,11 @@ jobs:
           echo "=> Saved $(formatByteCount $SAVED)"
 
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Terraform min/max versions
         id: minMax
-        uses: clowdhaus/terraform-min-max@v2.1.0
+        uses: clowdhaus/terraform-min-max@v3.0.1
         with:
           directory: ${{ matrix.directory }}
 
@@ -95,7 +95,7 @@ jobs:
     needs: collectInputs
     steps:
       - name: Install rmz
-        uses: jaxxstorm/action-install-gh-release@v2.1.0
+        uses: jaxxstorm/action-install-gh-release@v3.0.0
         with:
           repo: SUPERCILEX/fuc
           asset-name: x86_64-unknown-linux-gnu-rmz
@@ -122,20 +122,24 @@ jobs:
           if [[ ${{ github.repository }} == terraform-aws-modules/terraform-aws-security-group ]]; then
             sudo rmz -f /usr/share/dotnet &
             sudo rmz -f /usr/local/.ghcup &
-            sudo apt-get -qq remove -y 'azure-.*'
-            sudo apt-get -qq remove -y 'cpp-.*'
-            sudo apt-get -qq remove -y 'dotnet-runtime-.*'
-            sudo apt-get -qq remove -y 'google-.*'
-            sudo apt-get -qq remove -y 'libclang-.*'
-            sudo apt-get -qq remove -y 'libllvm.*'
-            sudo apt-get -qq remove -y 'llvm-.*'
-            sudo apt-get -qq remove -y 'mysql-.*'
-            sudo apt-get -qq remove -y 'postgresql-.*'
-            sudo apt-get -qq remove -y 'php.*'
-            sudo apt-get -qq remove -y 'temurin-.*'
-            sudo apt-get -qq remove -y kubectl firefox mono-devel
+            # Disk cleanup is best-effort; tolerate transient apt mirror failures
+            set +e
+            sudo apt-get -qq update -y
+            sudo apt-get -qq remove -y --fix-missing 'azure-.*'
+            sudo apt-get -qq remove -y --fix-missing 'cpp-.*'
+            sudo apt-get -qq remove -y --fix-missing 'dotnet-runtime-.*'
+            sudo apt-get -qq remove -y --fix-missing 'google-.*'
+            sudo apt-get -qq remove -y --fix-missing 'libclang-.*'
+            sudo apt-get -qq remove -y --fix-missing 'libllvm.*'
+            sudo apt-get -qq remove -y --fix-missing 'llvm-.*'
+            sudo apt-get -qq remove -y --fix-missing 'mysql-.*'
+            sudo apt-get -qq remove -y --fix-missing 'postgresql-.*'
+            sudo apt-get -qq remove -y --fix-missing 'php.*'
+            sudo apt-get -qq remove -y --fix-missing 'temurin-.*'
+            sudo apt-get -qq remove -y --fix-missing kubectl firefox mono-devel
             sudo apt-get -qq autoremove -y
             sudo apt-get -qq clean
+            set -e
           fi
 
           wait
@@ -145,14 +149,14 @@ jobs:
           echo "=> Saved $(formatByteCount $SAVED)"
 
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{github.event.pull_request.head.repo.full_name}}
 
       - name: Terraform min/max versions
         id: minMax
-        uses: clowdhaus/terraform-min-max@v2.1.0
+        uses: clowdhaus/terraform-min-max@v3.0.1
 
       - name: Hide template dir
         # Special to this repo, we don't want to check this dir

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,26 +20,31 @@ jobs:
     if: github.repository_owner == 'terraform-aws-modules'
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
           fetch-depth: 0
 
       - name: Set correct Node.js version
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: 24
 
       - name: Install dependencies
+        # conventional-changelog-conventionalcommits is held at 9.x on purpose.
+        # v10 replaced its handlebars templates with render functions, which need
+        # conventional-changelog-writer v9. semantic-release 25 still resolves
+        # writer v8, so v10 renders empty release notes without erroring.
+        # See https://github.com/semantic-release/release-notes-generator/issues/992
         run: |
           npm install \
-            @semantic-release/changelog@6.0.3 \
-            @semantic-release/git@10.0.1 \
-            conventional-changelog-conventionalcommits@9.1.0
+            @semantic-release/changelog@7.0.0 \
+            @semantic-release/git@11.0.1 \
+            conventional-changelog-conventionalcommits@9.3.1
 
       - name: Release
-        uses: cycjimmy/semantic-release-action@v5
+        uses: cycjimmy/semantic-release-action@v6.0.0
         with:
-          semantic_version: 25.0.0
+          semantic_version: 25.0.8
         env:
           GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}

--- a/.github/workflows/stale-actions.yaml
+++ b/.github/workflows/stale-actions.yaml
@@ -7,7 +7,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v10
+      - uses: actions/stale@v11
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           # Staling issues and PR's

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@
 # Crash log files
 crash.log
 
-# Exclude all .tfvars files, which are likely to contain sentitive data, such as
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
 # password, private keys, and other secrets. These should not be part of version
 # control as they are data points which are potentially sensitive and subject
 # to change depending on the environment.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.103.0
+    rev: v1.108.1
     hooks:
       - id: terraform_fmt
       - id: terraform_docs

--- a/README.md
+++ b/README.md
@@ -78,14 +78,14 @@ Examples codified under the [`examples`](https://github.com/terraform-aws-module
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.63 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.63 |
 
 ## Modules
@@ -95,7 +95,7 @@ No modules.
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_grafana_license_association.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/grafana_license_association) | resource |
 | [aws_grafana_role_association.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/grafana_role_association) | resource |
 | [aws_grafana_workspace.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/grafana_workspace) | resource |
@@ -118,7 +118,7 @@ No modules.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_account_access_type"></a> [account\_access\_type](#input\_account\_access\_type) | The type of account access for the workspace. Valid values are `CURRENT_ACCOUNT` and `ORGANIZATION` | `string` | `"CURRENT_ACCOUNT"` | no |
 | <a name="input_associate_license"></a> [associate\_license](#input\_associate\_license) | Determines whether a license will be associated with the workspace | `bool` | `true` | no |
 | <a name="input_authentication_providers"></a> [authentication\_providers](#input\_authentication\_providers) | The authentication providers for the workspace. Valid values are `AWS_SSO`, `SAML`, or both | `list(string)` | <pre>[<br/>  "AWS_SSO"<br/>]</pre> | no |
@@ -179,7 +179,7 @@ No modules.
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_license_expiration"></a> [license\_expiration](#output\_license\_expiration) | If `license_type` is set to `ENTERPRISE`, this is the expiration date of the enterprise license |
 | <a name="output_license_free_trial_expiration"></a> [license\_free\_trial\_expiration](#output\_license\_free\_trial\_expiration) | If `license_type` is set to `ENTERPRISE_FREE_TRIAL`, this is the expiration date of the free trial |
 | <a name="output_saml_configuration_status"></a> [saml\_configuration\_status](#output\_saml\_configuration\_status) | Status of the SAML configuration |

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -22,20 +22,20 @@ Note that this example may create resources which will incur monetary charges on
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.63 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.63 |
 
 ## Modules
 
 | Name | Source | Version |
-|------|--------|---------|
+| ---- | ------ | ------- |
 | <a name="module_managed_grafana"></a> [managed\_grafana](#module\_managed\_grafana) | ../.. | n/a |
 | <a name="module_managed_grafana_default"></a> [managed\_grafana\_default](#module\_managed\_grafana\_default) | ../.. | n/a |
 | <a name="module_managed_grafana_disabled"></a> [managed\_grafana\_disabled](#module\_managed\_grafana\_disabled) | ../.. | n/a |
@@ -44,7 +44,7 @@ Note that this example may create resources which will incur monetary charges on
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
 
 ## Inputs
@@ -54,7 +54,7 @@ No inputs.
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_license_expiration"></a> [license\_expiration](#output\_license\_expiration) | If `license_type` is set to `ENTERPRISE`, this is the expiration date of the enterprise license |
 | <a name="output_license_free_trial_expiration"></a> [license\_free\_trial\_expiration](#output\_license\_free\_trial\_expiration) | If `license_type` is set to `ENTERPRISE_FREE_TRIAL`, this is the expiration date of the free trial |
 | <a name="output_saml_configuration_status"></a> [saml\_configuration\_status](#output\_saml\_configuration\_status) | Status of the SAML configuration |


### PR DESCRIPTION
## Description

- Update GitHub Actions to their latest versions:
  - `actions/checkout` v5 -> v7
  - `actions/setup-node` v6 -> v7
  - `actions/setup-python` v5 -> v7 (module specific workflows only)
  - `actions/stale` v10 -> v11
  - `dessant/lock-threads` v5 -> v6
  - `cycjimmy/semantic-release-action` v5 -> v6.0.0
  - `jaxxstorm/action-install-gh-release` v2.1.0 -> v3.0.0
  - `clowdhaus/terraform-min-max` v2.1.0 -> v3.0.1
  - `hashicorp/setup-terraform` v3 -> v4 (module specific workflows only)
- Update the tool versions used by the pre-commit workflow:
  - `terraform-docs` v0.20.0 -> v0.24.0
  - `tflint` v0.59.1 -> v0.64.0
- Update the release workflow dependencies:
  - `semantic-release` 25.0.0 -> 25.0.8
  - `@semantic-release/changelog` 6.0.3 -> 7.0.0
  - `@semantic-release/git` 10.0.1 -> 11.0.1
  - `conventional-changelog-conventionalcommits` 9.1.0 -> 9.3.1
- Update pre-commit hook versions via `pre-commit autoupdate` and re-format with `pre-commit run -a`
- Roll the hardened disk cleanup step out to all modules. The `apt-get` removals are now
  best effort, so a transient package mirror failure no longer fails the job.

### Note on `conventional-changelog-conventionalcommits`

This is intentionally held at the 9.x line rather than the latest 10.x. Version 10 replaced
its handlebars templates with render functions, which require `conventional-changelog-writer`
v9. `semantic-release` 25 still resolves `conventional-changelog-writer` v8, so the preset
loads without error but every release note and changelog entry renders empty. This is tracked
upstream in https://github.com/semantic-release/release-notes-generator/issues/992 and the
reasoning is recorded as a comment in the release workflow so it does not get "fixed" back
to 10.x by a future update.

## Motivation and Context

- Keeps our workflows on supported action versions
- Standardizes the common CI files across modules so these updates stay automatable

## Breaking Changes

- No

## How Has This Been Tested?

- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request
